### PR TITLE
English editing and rename

### DIFF
--- a/media/stump-volume-control/README
+++ b/media/stump-volume-control/README
@@ -1,0 +1,28 @@
+very simple volume control for the window manager StumpWM
+---------------------------------------------------------
+
+Just support the three volume control keys on many keyboards.
+
+Depends on amixer which is started via RUN-SHELL-COMMAND.
+
+Hacked by Max-Gerd Retzlaff.
+
+
+loading and configuration
+-------------------------
+
+You can automatically load the module by adding this to your
+~/.stumpwm.d/init.lisp:
+
+  (load-module "stump-volume-control")
+
+Then assign the three commands volume-up, volume-down, volume-toggle-mute
+globally to some keys. If your keyboards has got them you can use the
+typical volume control keys:
+
+  (define-key *top-map* (kbd "XF86AudioRaiseVolume") "volume-up")
+  (define-key *top-map* (kbd "XF86AudioLowerVolume") "volume-down")
+  (define-key *top-map* (kbd "XF86AudioMute") "volume-toggle-mute")
+
+But you have to add it yourself to your ~/.stumpwm.d/init.lisp as I consider
+it bad manners to define global keys in a module.

--- a/media/stump-volume-control/README
+++ b/media/stump-volume-control/README
@@ -34,3 +34,10 @@ value of the exported variable STUMP-VOLUME-CONTROL:*SOUND-CARD*. For
 example, by adding to your ~/.stumpwm.d/init.lisp:
 
   (setf stump-volume-control:*sound-card* 1)
+
+
+PulseAudio mutes more than it unmutes. There is a hack that will also
+unmute the outputs. See comment in VOLUME-TOGGLE-MUTE for more details.
+The hack is deactivated by default. You can activate it with:
+
+  (setf stump-volume-control:*pulse-audio-unmute-hack* t)

--- a/media/stump-volume-control/README
+++ b/media/stump-volume-control/README
@@ -1,5 +1,5 @@
-very simple volume control for the window manager StumpWM
----------------------------------------------------------
+Minimalistic amixer-based volume control for the window manager StumpWM
+-----------------------------------------------------------------------
 
 Just support the three volume control keys on many keyboards.
 

--- a/media/stump-volume-control/README
+++ b/media/stump-volume-control/README
@@ -39,17 +39,32 @@ example, by adding to your ~/.stumpwm.d/init.lisp:
   (setf stump-volume-control:*sound-card* 1)
 
 
-PulseAudio unmute hack
-----------------------
+PulseAudio compatibility
+------------------------
 
-This simple volume control module works mainly for ALSA as it uses
-amixer, the "command-line mixer for [the] ALSA soundcard driver".
+This minimalistic volume control module works mainly for ALSA as it uses
+amixer, the "command-line mixer for [the] ALSA sound card driver".
 It might work also for PulseAudio as there are compatibility layers
 but there might be some shortcomings.
 
-Here is a workaround hack to address one problem that was observed:
-PulseAudio mutes more than it unmutes. There is a hack that will also
-unmute the outputs. See comment in VOLUME-TOGGLE-MUTE for more details.
-The hack is deactivated by default. You can activate it with:
+Here is a little workaround to address one problem that was observed:
+PulseAudio mutes more than it unmutes. This module includes hack that
+will explicitly unmute the audio outputs when toggling audio back on.
+It can be controlled by altering the list stored in the exported
+variable STUMP-VOLUME-CONTROL:*PULSE-AUDIO-UNMUTE-OUTPUTS*. By default,
+it is set to '("Speaker" "Headphone") as "Speaker" and "Headphone" are
+the generic output names.
 
-  (setf stump-volume-control:*pulse-audio-unmute-hack* t)
+If your hardware uses special names, such as, for example, "Megaphone"
+and "Leslie speaker", add this to your ~/.stumpwm.d/init.lisp:
+
+  (setf stump-volume-control:*pulse-audio-unmute-outputs*
+        '("Megaphone" "Leslie speaker"))
+
+Change to NIL if you just use ALSA and do not want the extra calls to
+be executed (which will fail silently if you do not have the outputs),
+by adding to your  ~/.stumpwm.d/init.lisp instead:
+
+  (setf stump-volume-control:*pulse-audio-unmute-outputs* nil)
+
+(And now I have again spend more time on the dreaded PulseAudio...)

--- a/media/stump-volume-control/README
+++ b/media/stump-volume-control/README
@@ -26,3 +26,11 @@ typical volume control keys:
 
 But you have to add it yourself to your ~/.stumpwm.d/init.lisp as I consider
 it bad manners to define global keys in a module.
+
+
+If you do not want to control the sound card that ALSA considers your
+first one (that is, sound card number 0, the default), just alter the
+value of the exported variable STUMP-VOLUME-CONTROL:*SOUND-CARD*. For
+example, by adding to your ~/.stumpwm.d/init.lisp:
+
+  (setf stump-volume-control:*sound-card* 1)

--- a/media/stump-volume-control/README
+++ b/media/stump-volume-control/README
@@ -38,6 +38,11 @@ example, by adding to your ~/.stumpwm.d/init.lisp:
 
   (setf stump-volume-control:*sound-card* 1)
 
+Set to NIL to not select any specific sound card explicitly by adding
+to your ~/.stumpwm.d/init.lisp instead:
+
+  (setf stump-volume-control:*sound-card* nil)
+
 
 PulseAudio compatibility
 ------------------------

--- a/media/stump-volume-control/README
+++ b/media/stump-volume-control/README
@@ -36,6 +36,12 @@ example, by adding to your ~/.stumpwm.d/init.lisp:
   (setf stump-volume-control:*sound-card* 1)
 
 
+This simple volume control module works mainly for ALSA as it uses
+amixer, the "command-line mixer for [the] ALSA soundcard driver".
+It might work also for PulseAudio as there are compatibility layers
+but there might be some shortcomings. Here is a workaround hack to
+address one problem that was observed:
+
 PulseAudio mutes more than it unmutes. There is a hack that will also
 unmute the outputs. See comment in VOLUME-TOGGLE-MUTE for more details.
 The hack is deactivated by default. You can activate it with:

--- a/media/stump-volume-control/README
+++ b/media/stump-volume-control/README
@@ -28,6 +28,9 @@ But you have to add it yourself to your ~/.stumpwm.d/init.lisp as I consider
 it bad manners to define global keys in a module.
 
 
+selecting the sound card
+------------------------
+
 If you do not want to control the sound card that ALSA considers your
 first one (that is, sound card number 0, the default), just alter the
 value of the exported variable STUMP-VOLUME-CONTROL:*SOUND-CARD*. For
@@ -36,12 +39,15 @@ example, by adding to your ~/.stumpwm.d/init.lisp:
   (setf stump-volume-control:*sound-card* 1)
 
 
+PulseAudio unmute hack
+----------------------
+
 This simple volume control module works mainly for ALSA as it uses
 amixer, the "command-line mixer for [the] ALSA soundcard driver".
 It might work also for PulseAudio as there are compatibility layers
-but there might be some shortcomings. Here is a workaround hack to
-address one problem that was observed:
+but there might be some shortcomings.
 
+Here is a workaround hack to address one problem that was observed:
 PulseAudio mutes more than it unmutes. There is a hack that will also
 unmute the outputs. See comment in VOLUME-TOGGLE-MUTE for more details.
 The hack is deactivated by default. You can activate it with:

--- a/media/stump-volume-control/package.lisp
+++ b/media/stump-volume-control/package.lisp
@@ -1,0 +1,5 @@
+(in-package :common-lisp-user)
+
+(defpackage #:stump-volume-control
+  (:use #:cl #:stumpwm)
+  (:export #:volume-up #:volume-down #:volume-toggle-mute))

--- a/media/stump-volume-control/package.lisp
+++ b/media/stump-volume-control/package.lisp
@@ -2,4 +2,5 @@
 
 (defpackage #:stump-volume-control
   (:use #:cl #:stumpwm)
-  (:export #:volume-up #:volume-down #:volume-toggle-mute #:*sound-card*))
+  (:export #:volume-up #:volume-down #:volume-toggle-mute
+           #:*sound-card* #:*pulse-audio-unmute-hack*))

--- a/media/stump-volume-control/package.lisp
+++ b/media/stump-volume-control/package.lisp
@@ -2,4 +2,4 @@
 
 (defpackage #:stump-volume-control
   (:use #:cl #:stumpwm)
-  (:export #:volume-up #:volume-down #:volume-toggle-mute))
+  (:export #:volume-up #:volume-down #:volume-toggle-mute #:*sound-card*))

--- a/media/stump-volume-control/package.lisp
+++ b/media/stump-volume-control/package.lisp
@@ -3,4 +3,4 @@
 (defpackage #:stump-volume-control
   (:use #:cl #:stumpwm)
   (:export #:volume-up #:volume-down #:volume-toggle-mute
-           #:*sound-card* #:*pulse-audio-unmute-hack*))
+           #:*sound-card* #:*pulse-audio-unmute-outputs*))

--- a/media/stump-volume-control/stump-volume-control.asd
+++ b/media/stump-volume-control/stump-volume-control.asd
@@ -1,0 +1,6 @@
+(asdf:defsystem #:stump-volume-control
+  :description "very simple volume control for stumpvm"
+  :author "Max-Gerd Retzlaff"
+  :depends-on (#:stumpwm)
+  :components ((:file "package")
+               (:file "volume-control" :depends-on ("package"))))

--- a/media/stump-volume-control/stump-volume-control.asd
+++ b/media/stump-volume-control/stump-volume-control.asd
@@ -1,5 +1,5 @@
 (asdf:defsystem #:stump-volume-control
-  :description "very simple volume control for stumpvm"
+  :description "Minimalistic amixer-based volume control for StumpWM."
   :author "Max-Gerd Retzlaff"
   :depends-on (#:stumpwm)
   :components ((:file "package")

--- a/media/stump-volume-control/volume-control.lisp
+++ b/media/stump-volume-control/volume-control.lisp
@@ -1,14 +1,18 @@
 (in-package :stump-volume-control)
 
+(defvar *sound-card* 0
+  "number of the sound card to control via amixer")
+
 (defcommand volume-up () ()
-  (run-shell-command "amixer -c 0 sset Master playback 2db+")
+  (run-shell-command (format nil "amixer -c ~d sset Master playback 2db+" *sound-card*))
   (message "Audio bit lowder."))
 
 (defcommand volume-down () ()
-  (run-shell-command "amixer -c 0 sset Master playback 2db-")
+  (run-shell-command (format nil "amixer -c ~d sset Master playback 2db-" *sound-card*))
   (message "Audio bit quieter."))
 
 (defcommand volume-toggle-mute () ()
   (let ((muted (search "[off]"
-		       (run-shell-command "amixer -c 0 sset Master playback toggle" t))))
+		       (run-shell-command (format nil "amixer -c ~d sset Master playback toggle" *sound-card*)
+                                          t))))
     (message (concatenate 'string "Audio " (if muted "muted" "back on") "."))))

--- a/media/stump-volume-control/volume-control.lisp
+++ b/media/stump-volume-control/volume-control.lisp
@@ -13,6 +13,6 @@
 
 (defcommand volume-toggle-mute () ()
   (let ((muted (search "[off]"
-		       (run-shell-command (format nil "amixer -c ~d sset Master playback toggle" *sound-card*)
+                       (run-shell-command (format nil "amixer -c ~d sset Master playback toggle" *sound-card*)
                                           t))))
     (message (concatenate 'string "Audio " (if muted "muted" "back on") "."))))

--- a/media/stump-volume-control/volume-control.lisp
+++ b/media/stump-volume-control/volume-control.lisp
@@ -3,6 +3,10 @@
 (defvar *sound-card* 0
   "number of the sound card to control via amixer")
 
+(defvar *pulse-audio-unmute-hack* nil
+  "PulseAudio mutes more than it unmutes; this hack will also unmute the outputs
+  (See comment in VOLUME-TOGGLE-MUTE for more details.)")
+
 (defcommand volume-up () ()
   (run-shell-command (format nil "amixer -c ~d sset Master playback 2db+" *sound-card*))
   (message "Audio bit lowder."))
@@ -15,9 +19,16 @@
   (let ((muted (search "[off]"
                        (run-shell-command (format nil "amixer -c ~d sset Master playback toggle" *sound-card*)
                                           t))))
-    (unless muted
-      ;; hack for pulseaudio: on my system with PulseAudio muting Master also mutes Speaker
-      ;; but when unmuting Master Speaker stays muted, so unmuting it seperately.
-      ;; (On my system with just ALSA there is no Speaker so this will fail, but just silently...)
-      (run-shell-command (format nil "amixer -c ~d sset Speaker playback toggle" *sound-card*)))
+    (when (and (not muted)
+               *pulse-audio-unmute-hack*)
+      ;; hack for pulseaudio:
+      ;;   On my system with PulseAudio muting 'Master' also mutes the
+      ;;   output 'Speaker' (or 'Headphone') but when unmuting 'Master'
+      ;;   the output 'Speaker (or 'Headphone') stays muted, so we just
+      ;;   explicitly unmute both seperately. This seems to work well.
+      ;;
+      ;;   As noted, this is a hack. It might work for you or it might not.
+      ;;   Of course, we cannot fix PulseAudio with a small hack here.
+      (run-shell-command (format nil "amixer -c ~d sset Speaker playback on" *sound-card*))
+      (run-shell-command (format nil "amixer -c ~d sset Headphone playback on" *sound-card*)))
     (message (concatenate 'string "Audio " (if muted "muted" "back on") "."))))

--- a/media/stump-volume-control/volume-control.lisp
+++ b/media/stump-volume-control/volume-control.lisp
@@ -34,4 +34,7 @@
         (run-shell-command (format nil "amixer -c ~d sset ~s playback on"
                                    *sound-card*
                                    output))))
-    (message (concatenate 'string "Audio " (if muted "muted" "back on") "."))))
+    (message (if muted
+                 "Audio muted."
+                 (format nil "Audio back on.~@[~%(Also switched on outputs: ~{~a~^, ~}.)~]"
+                         *pulse-audio-unmute-outputs*)))))

--- a/media/stump-volume-control/volume-control.lisp
+++ b/media/stump-volume-control/volume-control.lisp
@@ -1,0 +1,14 @@
+(in-package :stump-volume-control)
+
+(defcommand volume-up () ()
+  (run-shell-command "amixer -c 0 sset Master playback 2db+")
+  (message "Audio bit lowder."))
+
+(defcommand volume-down () ()
+  (run-shell-command "amixer -c 0 sset Master playback 2db-")
+  (message "Audio bit quieter."))
+
+(defcommand volume-toggle-mute () ()
+  (let ((muted (search "[off]"
+		       (run-shell-command "amixer -c 0 sset Master playback toggle" t))))
+    (message (concatenate 'string "Audio " (if muted "muted" "back on") "."))))

--- a/media/stump-volume-control/volume-control.lisp
+++ b/media/stump-volume-control/volume-control.lisp
@@ -15,4 +15,9 @@
   (let ((muted (search "[off]"
                        (run-shell-command (format nil "amixer -c ~d sset Master playback toggle" *sound-card*)
                                           t))))
+    (unless muted
+      ;; hack for pulseaudio: on my system with PulseAudio muting Master also mutes Speaker
+      ;; but when unmuting Master Speaker stays muted, so unmuting it seperately.
+      ;; (On my system with just ALSA there is no Speaker so this will fail, but just silently...)
+      (run-shell-command (format nil "amixer -c ~d sset Speaker playback toggle" *sound-card*)))
     (message (concatenate 'string "Audio " (if muted "muted" "back on") "."))))

--- a/media/stump-volume-control/volume-control.lisp
+++ b/media/stump-volume-control/volume-control.lisp
@@ -3,9 +3,16 @@
 (defvar *sound-card* 0
   "number of the sound card to control via amixer")
 
-(defvar *pulse-audio-unmute-hack* nil
-  "PulseAudio mutes more than it unmutes; this hack will also unmute the outputs
-  (See comment in VOLUME-TOGGLE-MUTE for more details.)")
+(defvar *pulse-audio-unmute-outputs* '("Speaker" "Headphone")
+  "PulseAudio mutes more than it unmutes; when this variable is set,
+  the listed audio outputs will explicitly be unmuted when toggling
+  audio back on.
+
+  \"Speaker\" and \"Headphone\" are the generic output names but
+  some hardware might expose special names.
+
+  Change to NIL if you just use ALSA and do not want the extra calls to
+  be executed (which will fail silently if you do not have the outputs).")
 
 (defcommand volume-up () ()
   (run-shell-command (format nil "amixer -c ~d sset Master playback 2db+" *sound-card*))
@@ -17,18 +24,14 @@
 
 (defcommand volume-toggle-mute () ()
   (let ((muted (search "[off]"
-                       (run-shell-command (format nil "amixer -c ~d sset Master playback toggle" *sound-card*)
-                                          t))))
-    (when (and (not muted)
-               *pulse-audio-unmute-hack*)
-      ;; hack for pulseaudio:
-      ;;   On my system with PulseAudio muting 'Master' also mutes the
-      ;;   output 'Speaker' (or 'Headphone') but when unmuting 'Master'
-      ;;   the output 'Speaker (or 'Headphone') stays muted, so we just
-      ;;   explicitly unmute both seperately. This seems to work well.
-      ;;
-      ;;   As noted, this is a hack. It might work for you or it might not.
-      ;;   Of course, we cannot fix PulseAudio with a small hack here.
-      (run-shell-command (format nil "amixer -c ~d sset Speaker playback on" *sound-card*))
-      (run-shell-command (format nil "amixer -c ~d sset Headphone playback on" *sound-card*)))
+                       (run-shell-command
+                        (format nil "amixer -c ~d sset Master playback toggle" *sound-card*)
+                        t))))
+    (when (not muted)
+      (dolist (output *pulse-audio-unmute-outputs*)
+        ;; Just unmute all listed outputs explicitly when going back on.
+        ;; Of course, we cannot fix PulseAudio with a small hack here.
+        (run-shell-command (format nil "amixer -c ~d sset ~s playback on"
+                                   *sound-card*
+                                   output))))
     (message (concatenate 'string "Audio " (if muted "muted" "back on") "."))))

--- a/media/stump-volume-control/volume-control.lisp
+++ b/media/stump-volume-control/volume-control.lisp
@@ -1,7 +1,8 @@
 (in-package :stump-volume-control)
 
 (defvar *sound-card* 0
-  "number of the sound card to control via amixer")
+  "number of the sound card to control via amixer;
+  set to NIL to not select any specific sound card explicitly")
 
 (defvar *pulse-audio-unmute-outputs* '("Speaker" "Headphone")
   "PulseAudio mutes more than it unmutes; when this variable is set,
@@ -15,23 +16,23 @@
   be executed (which will fail silently if you do not have the outputs).")
 
 (defcommand volume-up () ()
-  (run-shell-command (format nil "amixer -c ~d sset Master playback 2db+" *sound-card*))
+  (run-shell-command (format nil "amixer ~@[-c ~d ~]sset Master playback 2db+" *sound-card*))
   (message "Audio bit lowder."))
 
 (defcommand volume-down () ()
-  (run-shell-command (format nil "amixer -c ~d sset Master playback 2db-" *sound-card*))
+  (run-shell-command (format nil "amixer ~@[-c ~d ~]sset Master playback 2db-" *sound-card*))
   (message "Audio bit quieter."))
 
 (defcommand volume-toggle-mute () ()
   (let ((muted (search "[off]"
                        (run-shell-command
-                        (format nil "amixer -c ~d sset Master playback toggle" *sound-card*)
+                        (format nil "amixer ~@[-c ~d ~]sset Master playback toggle" *sound-card*)
                         t))))
     (when (not muted)
       (dolist (output *pulse-audio-unmute-outputs*)
         ;; Just unmute all listed outputs explicitly when going back on.
         ;; Of course, we cannot fix PulseAudio with a small hack here.
-        (run-shell-command (format nil "amixer -c ~d sset ~s playback on"
+        (run-shell-command (format nil "amixer ~@[-c ~d ~]sset ~s playback on"
                                    *sound-card*
                                    output))))
     (message (if muted


### PR DESCRIPTION
I updated a lot of the English in this package, including
- Renaming it
- Fixing typos
- Using more terse English so the documentation is shorter

It is intended to be merely editing advice, so please take my edits and suit them to your own needs and style.

The following paragraph was left alone by me, since I think it just needs to be rewritten from scratch.

> Here is a workaround to address one problem: PulseAudio mutes more than it
unmutes. Will explicitly unmute the audio outputs when toggling audio back on.
It is controlled with the list stored in the variable
VOLUME-CONTROL:*PULSE-AUDIO-UNMUTE-OUTPUTS*. By default, it is set to
'("Speaker" "Headphone") as "Speaker" and "Headphone" are the generic output
names.
